### PR TITLE
Bug in GedcomXDate.getDuration

### DIFF
--- a/test/util.js
+++ b/test/util.js
@@ -331,13 +331,13 @@ describe('Util', function(){
 
     });
 
-    it('should error if start > end years', function(){
+    it('should error if start >= end years', function(){
 
-      var start = new Simple('+0999-01-01T00:00:00'),
-          end = new Simple('+1000-01-01T00:00:00');
+      var start = new Simple('+1900-07-03'),
+          end = new Simple('+1899-05-10');
 
       expect(function() {
-        duration = GedcomXDate.getDuration(end, start);
+        duration = GedcomXDate.getDuration(start, end);
       }).to.throw(Error, 'Start Date must be less than End Date');
 
     });


### PR DESCRIPTION
I modified the test to show that it sometimes fails. I don't understand enough about how it works to get too much detail. All I could figure out is that it works when the only thing that differs between the two dates is the year, but not if anything else differs.

I don't actually expect you to merge this; just wanted to show you my code.
