### PR TITLE
Add now() and fromJSDate()

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,5 +216,8 @@ Adds duration to date and returns a new Single date.
 ### GedcomXDate.multiplyDuration(duration, number)
 Multiplies a duration by a positive number and returns a new Duration.
 
+### GedcomXDate.fromJSDate(Date)
+Returns a Simple date representation of the given JavaScript Date.
+
 ### GedcomXDate.now()
-Returns a Simple date representing the current date and time
+Returns a Simple date representing the current date and time.

--- a/lib/gedcomx-date.js
+++ b/lib/gedcomx-date.js
@@ -57,4 +57,9 @@ GedcomXDate.daysInMonth = GedUtil.daysInMonth;
  */
 GedcomXDate.now = GedUtil.now;
 
+/**
+ * Expose fromJSDate.
+ */
+GedcomXDate.fromJSDate = GedUtil.fromJSDate;
+
 module.exports = GedcomXDate;

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,7 +8,8 @@ module.exports = {
   daysInMonth: GlobalUtil.daysInMonth,
   addDuration: addDuration,
   multiplyDuration: multiplyDuration,
-  now: now
+  now: now,
+  fromJSDate: fromJSDate
 }
 
 /**
@@ -283,14 +284,6 @@ function getDuration(startDate, endDate) {
 }
 
 /**
- * Returns a new single date representing the current date
- */
-function now(){
-  // Remove the millisecond time component
-  return new Simple('+' + new Date().toISOString().replace(/\.\d{3}/,''));
-};
-
-/**
  * Ensures that both start and end have values where the other has values.
  * For example, if start has minutes but end does not, this function
  * will initialize minutes in end.
@@ -420,3 +413,18 @@ function getObjFromDate(date, adjustTimezone) {
   }
   return obj;
 }
+
+/**
+ * Returns a new single date representing the current date
+ */
+function now(){
+  return fromJSDate(new Date());
+}
+
+/**
+ * Return a simple date object from a JavaScript date object
+ */
+function fromJSDate(date){
+  // Remove the millisecond time component
+  return new Simple('+' + date.toISOString().replace(/\.\d{3}/,''));
+};

--- a/test/util.js
+++ b/test/util.js
@@ -385,6 +385,24 @@ describe('Util', function(){
 
   });
   
+  describe("#fromJSDate()", function(){
+  
+    it('should return the correct simple date', function(){
+      var jsDate = new Date('October 6 1984'),
+          gxDate = GedcomXDate.fromJSDate(jsDate);
+      
+      expect(gxDate.isApproximate()).to.be.false;
+      expect(gxDate.getYear()).to.equal(1984);
+      expect(gxDate.getMonth()).to.equal(10);
+      expect(gxDate.getDay()).to.equal(6);
+      expect(gxDate.getHours()).to.equal(0);
+      expect(gxDate.getMinutes()).to.equal(0);
+      expect(gxDate.getSeconds()).to.equal(0);
+      expect(gxDate.toFormalString()).to.equal('+1984-10-06T00:00:00Z');
+    });
+    
+  });
+  
   describe("#now()", function(){
   
     it('should return simple date representing current date and time', function(){


### PR DESCRIPTION
`fromJSDate()` returns a Simple date representation of the given JavaScript date.

`now()` returns a Simple date representation of the current date and time.

I didn't rebuild since the version number needs to be changed anyways if this is accepted.
