### PR TITLE
Enforce parameter types on getDuration()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -7,7 +7,9 @@ module.exports = {
   getDuration: getDuration,
   daysInMonth: GlobalUtil.daysInMonth,
   addDuration: addDuration,
-  multiplyDuration: multiplyDuration
+  multiplyDuration: multiplyDuration,
+  now: now,
+  fromJSDate: fromJSDate
 }
 
 /**
@@ -201,6 +203,10 @@ function addDuration(startDate, duration) {
  * Returns the duration between the starting and ending date.
  */
 function getDuration(startDate, endDate) {
+  
+  if(!(startDate instanceof Simple && endDate instanceof Simple)){
+    throw new Error('Start and end dates must be simple dates');
+  }
   
   var start = getObjFromDate(startDate, true),
       end = getObjFromDate(endDate, true),
@@ -411,3 +417,18 @@ function getObjFromDate(date, adjustTimezone) {
   }
   return obj;
 }
+
+/**
+ * Returns a new single date representing the current date
+ */
+function now(){
+  return fromJSDate(new Date());
+}
+
+/**
+ * Return a simple date object from a JavaScript date object
+ */
+function fromJSDate(date){
+  // Remove the millisecond time component
+  return new Simple('+' + date.toISOString().replace(/\.\d{3}/,''));
+};

--- a/test/util.js
+++ b/test/util.js
@@ -241,6 +241,15 @@ describe('Util', function(){
   
   describe("#getDuration(start, end)", function(){
     
+    it('should only accept simple dates', function(){
+      var start = new GedcomXDate('+1980/+1985'),
+          end = new Simple('+1990'),
+          fn = function(){
+            var duration = GedcomXDate.getDuration(start, end);
+          };
+      expect(fn).to.throw(/must be simple dates/);
+    });
+    
     it('should overflow seconds', function(){
 
       var start = new Simple('+0999-12-31T23:59:59'),


### PR DESCRIPTION
Passing in anything other than a Simple date will cause unexpected errors. Better to throw something more descriptive.
