### PR TITLE
Fix bug calculating days in duration

### DIFF
--- a/lib/simple.js
+++ b/lib/simple.js
@@ -27,7 +27,7 @@ function Simple() {
  */
 Simple.prototype._parse = function(str) {
 
-  var end = str.length;
+  var end = str.length,
       offset = 0;
 
   // There is a minimum length of 5 characters

--- a/lib/util.js
+++ b/lib/util.js
@@ -155,9 +155,6 @@ function addDuration(startDate, duration) {
       end.year += 1;
     }
   }
-  if(end.day != undefined) {
-    endString = '-'+('00'+end.day).substr(-2,2)+endString;
-  }
 
   if(duration.getMonths()) {
     end.month += duration.getMonths();
@@ -165,6 +162,19 @@ function addDuration(startDate, duration) {
   while(end.month && end.month > 12) {
     end.month -= 12;
     end.year += 1;
+  }
+  // After readjusting the month, check again for days overflow
+  if(end.day && end.day > GlobalUtil.daysInMonth(end.month, end.year)){
+    end.day = end.day - GlobalUtil.daysInMonth(end.month, end.year);
+    end.month += 1;
+    if(end.month > 12) {
+      end.month -= 12;
+      end.year += 1;
+    }
+  }
+  
+  if(end.day != undefined) {
+    endString = '-'+('00'+end.day).substr(-2,2)+endString;
   }
   if(end.month != undefined) {
     endString = '-'+('00'+end.month).substr(-2,2)+endString;

--- a/test/range.js
+++ b/test/range.js
@@ -125,7 +125,6 @@ describe('Range', function(){
 
     it('should calculate range correctly', function(){
       var range = new Range('+1000-02-03/+2000');
-
       expect(range.duration.getYears()).to.equal(999);
       expect(range.duration.getMonths()).to.equal(10);
       expect(range.duration.getDays()).to.equal(29);
@@ -133,7 +132,6 @@ describe('Range', function(){
 
     it('should calculate tricky range correctly', function(){
       var range = new Range('+1970-01-31/+1973-02-01');
-
       expect(range.duration.getYears()).to.equal(3);
       expect(range.duration.getMonths()).to.equal(undefined);
       expect(range.duration.getDays()).to.equal(1);
@@ -148,7 +146,6 @@ describe('Range', function(){
 
     it('should calculate approximate duration', function(){
       var range = new Range('A+1000/P1000Y');
-
       expect(range.end.getYear()).to.equal(2000);
       expect(range.isApproximate()).to.equal(true);
     });

--- a/test/util.js
+++ b/test/util.js
@@ -245,6 +245,15 @@ describe('Util', function(){
        expect(end.getMonth()).to.equal(3);
        expect(end.getDay()).to.equal(1);
     });
+    
+    it('complex case', function(){
+      var start = new Simple('+1771-08-30'),
+          duration = new Duration('P1M1D'),
+          end = GedcomXDate.addDuration(start, duration);
+      expect(end.getYear()).to.equal(1771);
+      expect(end.getMonth()).to.equal(10);
+      expect(end.getDay()).to.equal(1);
+    })
 
   });
 


### PR DESCRIPTION
This bug was manifest under the following conditions:
- Calculating duration
- Duration involved days and months
- Months of the start and end dates were different lengths (30 vs 31 days)
- The end day was smaller than the start day

It used the wrong month's days when calculating the overflow for the month. As you can see below I just needed to calculate the days after the overflow of the month was performed instead of before.
