### PR TITLE
Add compare function

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,26 @@ Returns a Simple date representation of the given JavaScript Date.
 
 ### GedcomXDate.now()
 Returns a Simple date representing the current date and time.
+
+### GedcomXDate.compare(date1, date2)
+Compare two dates. Only works for single dates.
+Dates may either be in string format or already be Single date objects.
+
+This function is designed to be used as the custom compare function
+for [Array.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
+Therefore it return 0 if the dates are equal, -1 if date1 occurs before date2,
+or 1 if date1 occurs after date2.
+
+```js
+
+// Dates as strings
+GedcomXDate.compare('+1845', '+1834-02-17');
+
+// Dates as objects
+var date1 = new GedcomXDate('+1394'),
+    date2 = new GedcomXDate('+1723-11-04');
+GedcomXDate.compare(date1, date2);
+
+// Mix and match
+GedcomXDate.compare('A+1845', new GedcomXDate('+1834-02-17'));
+```

--- a/lib/gedcomx-date.js
+++ b/lib/gedcomx-date.js
@@ -1,6 +1,5 @@
 var GedUtil = require('./util.js'),
     Simple = require('./simple.js'),
-    Duration = require('./duration.js'),
     Approximate = require('./approximate.js'),
     Recurring = require('./recurring.js'),
     Range = require('./range.js');
@@ -61,5 +60,10 @@ GedcomXDate.now = GedUtil.now;
  * Expose fromJSDate.
  */
 GedcomXDate.fromJSDate = GedUtil.fromJSDate;
+
+/**
+ * Expose compare.
+ */
+GedcomXDate.compare = GedUtil.compare;
 
 module.exports = GedcomXDate;

--- a/lib/simple.js
+++ b/lib/simple.js
@@ -27,7 +27,7 @@ function Simple() {
  */
 Simple.prototype._parse = function(str) {
 
-  var end = str.length;
+  var end = str.length,
       offset = 0;
 
   // There is a minimum length of 5 characters

--- a/lib/util.js
+++ b/lib/util.js
@@ -9,7 +9,8 @@ module.exports = {
   addDuration: addDuration,
   multiplyDuration: multiplyDuration,
   now: now,
-  fromJSDate: fromJSDate
+  fromJSDate: fromJSDate,
+  compare: compare
 }
 
 /**
@@ -431,4 +432,83 @@ function now(){
 function fromJSDate(date){
   // Remove the millisecond time component
   return new Simple('+' + date.toISOString().replace(/\.\d{3}/,''));
+};
+
+/**
+ * Compare two dates. Only works for single dates right now.
+ * Designed to be usable as a custom compare function for sorting an array of dates.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
+ */
+function compare(date1, date2){
+  
+  // Allow formal strings as input
+  if(isString(date1)){
+    if(date1[0] === 'A'){
+      date1 = new Approximate(date1);
+    } else {
+      date1 = new Simple(date1);
+    }
+  }
+  if(isString(date2)){
+    if(date2[0] === 'A'){
+      date2 = new Approximate(date2);
+    } else {
+      date2 = new Simple(date2);
+    }
+  }
+  
+  // Only allow simple dates
+  if(!(date1 instanceof Simple) || !(date2 instanceof Simple)){
+    throw new Error('Bad input. Can only compare simple dates.');
+  }
+  
+  // Compare date parts in descending order
+  var parts = [
+    '_year',
+    '_month',
+    '_day',
+    '_hours',
+    '_minutes',
+    '_seconds'
+  ];
+  
+  // We will short-circuit when we determine whether one
+  // date is greater than the other
+  for(var i = 0; i < parts.length; i++){
+    var part = parts[i];
+    
+    // If these parts match exactly, 
+    if(date1[part] === date2[part]){
+      continue;
+    }
+
+    // If either part is undefined then consider the dates equal.
+    // Undefined parts are only allowed for lower order positions and
+    // cannot occur if anything is defined in a lower order. For example,
+    // you can't have a year and day but no month. So once we see something
+    // that was undefined we know everything before that matched and
+    // therefore the dates are effectively equal (either we're done comparing
+    // because nothing else is defined or we're comparing two dates with
+    // different specifities, i.e. comparing +1900 to +1900-04)
+    if(typeof date1[part] === 'undefined' || typeof date2[part] === 'undefined'){
+      break;
+    }
+    
+    // By this point we're guaranteed that this part is defined in both dates
+    // so we can finally do some > and <
+    if(date1[part] > date2[part]){
+      return 1;
+    } else {
+      return -1;
+    }
+    
+  }
+  
+  // If we make it here then the dates are equal
+  return 0;
+  
+};
+
+function isString(obj){
+  return typeof obj === 'string' || obj instanceof String;
 };

--- a/test/util.js
+++ b/test/util.js
@@ -428,5 +428,72 @@ describe('Util', function(){
     });
   
   });
+  
+  describe("#compare()", function(){
+    
+    it('should throw error for non simple dates', function(){
+      expect(function(){
+        GedcomXDate.compare('+1980/+1984', '+1893-02-05');
+      }).to.throw(Error);
+    });
+    
+    it('should throw error for bad input', function(){
+      expect(function(){
+        GedcomXDate.compare('+1980', 1985);
+      }).to.throw(Error);
+      expect(function(){
+        GedcomXDate.compare(1980, '+1985');
+      }).to.throw(Error);
+    });
+    
+    it('should work for objects already created', function(){
+      var date1 = new GedcomXDate('+1776'),
+          date2 = new GedcomXDate('+1776');
+      expect(GedcomXDate.compare(date1, date2)).to.equal(0);
+    });
+    
+    it('should work for years', function(){
+      expect(GedcomXDate.compare('+1776', '+1776')).to.equal(0);
+      expect(GedcomXDate.compare('+1880', '+1893')).to.equal(-1);
+      expect(GedcomXDate.compare('+1880', '+1568')).to.equal(1);
+    });
+    
+    it('should work for years and months', function(){
+      expect(GedcomXDate.compare('+1776-03', '+1776-03')).to.equal(0);
+      expect(GedcomXDate.compare('+1776-01', '+1776-03')).to.equal(-1);
+      expect(GedcomXDate.compare('+1776-03', '+1776-01')).to.equal(1);
+      expect(GedcomXDate.compare('+1773-03', '+1776-03')).to.equal(-1);
+      expect(GedcomXDate.compare('+1778-03', '+1776-03')).to.equal(1);
+    });
+    
+    it('should work for years, months, and days', function(){
+      expect(GedcomXDate.compare('+1895-03-13', '+1895-03-13')).to.equal(0);
+      expect(GedcomXDate.compare('+1895-03-08', '+1895-03-13')).to.equal(-1);
+      expect(GedcomXDate.compare('+1895-03-23', '+1895-03-13')).to.equal(1);
+      expect(GedcomXDate.compare('+1852-03-13', '+1895-03-13')).to.equal(-1);
+      expect(GedcomXDate.compare('+1895-08-13', '+1895-03-13')).to.equal(1);
+    });
+    
+    it('should work for partial dates', function(){
+      expect(GedcomXDate.compare('+1776-03-05', '+1776')).to.equal(0);
+      expect(GedcomXDate.compare('+1776-01', '+1776-02-16')).to.equal(-1);
+      expect(GedcomXDate.compare('+1776-09', '+1776-01-19')).to.equal(1);
+    });
+    
+    it('should work for equal dates with different times', function(){
+      expect(GedcomXDate.compare('+1485-09-14T13:45:38','+1485-09-14T13:45:38')).to.equal(0);
+      expect(GedcomXDate.compare('+1485-09-14T02:45:38','+1485-09-14T13:45:38')).to.equal(-1);
+      expect(GedcomXDate.compare('+1485-09-14T13:45:51','+1485-09-14T13:45:38')).to.equal(1);
+    });
+    
+    it('should work for approximate dates too', function(){
+      expect(GedcomXDate.compare('A+1895-03-13', '+1895-03-13')).to.equal(0);
+      expect(GedcomXDate.compare('+1895-03-08', 'A+1895-03-13')).to.equal(-1);
+      expect(GedcomXDate.compare('A+1895-03-23', '+1895-03-13')).to.equal(1);
+      expect(GedcomXDate.compare('+1852-03-13', 'A+1895-03-13')).to.equal(-1);
+      expect(GedcomXDate.compare('A+1895-08-13', '+1895-03-13')).to.equal(1);
+    });
+    
+  });
 
 });


### PR DESCRIPTION
Regarding #3. Works for simple and approximate dates. Considers partial dates, `+1940`,  to equal more specified dates, `+1940-12-21`, it the defined parts match.