### PR TITLE
Fix timezone in formal string conversion

### DIFF
--- a/lib/simple.js
+++ b/lib/simple.js
@@ -388,7 +388,7 @@ Simple.prototype.toFormalString = function() {
   }
 
   if(this._hours != undefined || this._minutes != undefined || this._seconds != undefined) {
-    if(this._tzHours === 0 || this._tzMinutes === 0) {
+    if(this._tzHours === 0 && this._tzMinutes === 0) {
       simple += 'Z';
     } else {
       if(this._tzHours != undefined) {


### PR DESCRIPTION
Whenever the offset minutes are 0, the timezone was set to "Z" due to using or instead of and.